### PR TITLE
(maint)Adding loadbalancer manifests for HA

### DIFF
--- a/site/profile/manifests/loadbalancer.pp
+++ b/site/profile/manifests/loadbalancer.pp
@@ -1,0 +1,34 @@
+class profile::loadbalancer(
+  $balance_type   = 'roundrobin',
+  $stats_username = 'puppet',
+  $stats_password = 'puppet',
+  $stats_port     = 9090,
+){
+  class { 'haproxy':
+    global_options => {
+      'log'     => "${::ipaddress} local0",
+      'chroot'  => '/var/lib/haproxy',
+      'pidfile' => '/var/run/haproxy.pid',
+      'maxconn' => '4000',
+      'daemon'  => '',
+      'stats'   => 'socket /var/lib/haproxy/stats',
+    },
+  }
+
+  haproxy::listen { 'stats':
+    ipaddress        => '*',
+    ports            => "${stats_port}",
+    collect_exported => false,
+    options          => {
+      'mode'  => 'http',
+      'stats' => ['uri /', "auth ${stats_username}:${stats_password}"]
+    },
+  }
+
+  haproxy::listen { "compile":
+    ipaddress        => '*',
+    ports            => '8140',
+    collect_exported => true,
+    options => { 'balance' => $balance_type },
+  }
+}

--- a/site/profile/manifests/loadbalancer_exports.pp
+++ b/site/profile/manifests/loadbalancer_exports.pp
@@ -1,0 +1,13 @@
+class profile::loadbalancer_exports(
+  $haproxy_options = 'check',
+  $haproxy_ports   = '8140',
+){
+
+  @@haproxy::balancermember { "compile-${::fqdn}":
+    listening_service => 'compile',
+    server_names      => [$::fqdn, $::fqdn, $::fqdn],
+    ipaddresses       => pe_delete_undef_values(pe_unique([$::ipaddress, $::ipaddress_eth0, $::ipaddress_eth1])),
+    ports             => $haproxy_ports,
+    options           => $haproxy_options,
+  }
+}


### PR DESCRIPTION
These are the same manifests that pe_acceptance_tests use to configure a load balancer for scale testing.